### PR TITLE
Finish conversion for Bulletin_SPLs and SPL_CVE_IDs; Read and write JSON file

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -31,3 +31,49 @@ export const getSPLFunction = SPLFunction.getSPL;
 export const getBulletinFunction = bulletinFunction.getBulletin;
 export const getAndroidVersionFunction = androidVersionFunction.getAndroidVersion;
 
+//converter
+import * as data from './bulletin.json';
+
+const SPLsArray : any[] = [];
+const found : string[] = [];
+ for(const vulnerabilities of data.vulnerabilities){
+    const patchLevel = vulnerabilities.patch_level;  
+    if (found.indexOf(patchLevel) === -1) {
+        found.push(patchLevel);
+        SPLsArray.push(patchLevel);
+    }
+}
+const SPLs = {
+    'SPLs': SPLsArray
+ };
+const ASBs = { [data.ASB] : SPLs };
+const Bulletin_SPLs = {'ASBs': ASBs};
+
+const pubishDate = data.published;
+const result : Record<string, object> = {};
+for(const spl of SPLsArray){
+    const cveIDsArray : string[] = [];
+    const splDetails = {
+        'Publish_Date': pubishDate,
+        'CVE_IDs': cveIDsArray
+     };
+     for(const vulnerabilities of data.vulnerabilities){
+        const patchLevel = vulnerabilities.patch_level;
+        if(patchLevel === spl){
+            const cveID = vulnerabilities.CVE;
+            splDetails.CVE_IDs.push(cveID);
+        }
+        result[spl] = splDetails;
+      }
+}
+
+const SPL_CVE_IDs = {'SPLs' : result};
+const output = {SPL_CVE_IDs, Bulletin_SPLs};
+
+//TODO
+// const AOSP_VERSION_CVE_IDs 
+// const AOSP_VERSION_ASB_CVE_IDs 
+// const CVEs 
+
+const fs = require('fs');
+fs.writeFileSync('../convertedData.json', JSON.stringify(output));

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "resolveJsonModule": true
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION
Finish mapping for Bulletin_SPLs and SPL_CVE_IDs; Read the bulletin data from the json file and write to a new json file.

This works independently without cloud functions. However, I put it in the main index.ts file because it requires the same configuration to run. Please let me know if it should be placed in another directory.

PS: As discussed in our pod meeting, I didn't push the bulletin.json file. To run the converter code, please add bulletin.json manually in src.