### PR TITLE
Fix Error Check PR comments.

### DIFF
--- a/functions/src/errorChecks.ts
+++ b/functions/src/errorChecks.ts
@@ -1,16 +1,6 @@
 export function checkCVEValidity(ID: any): boolean {
   const regex = /^CVE-\d{4}-\d{3,7}$/;
   if (!regex.test(ID)) {
-    const hyphenString = ID.match(/-/g);
-    if (hyphenString) {
-      const hyphenCount = hyphenString.length;
-      const idCVEArray = ID.split("-");
-      if (hyphenCount === 3) {
-        if (idCVEArray[3].length === 1) {
-          return true;
-        }
-      }
-    }
     return false;
   }
   return true;
@@ -53,11 +43,11 @@ export function checkSPLValidity(ID: any): boolean {
 export function checkAndroidVersionValidity(ID: any): boolean {
   const regex = /^(\d{1}_\d{1}(_\d{1})?)$/g;
   if (!regex.test(ID)) {
-    const periodArray = ID.match(/./g);
-    if (periodArray) {
-      const periodCount = periodArray.length;
-      const idAndroidArray = ID.split(".");
-      if (periodCount === 3) {
+    const underscoreArray = ID.match(/_/g);
+    if (underscoreArray) {
+      const underscoreCount = underscoreArray.length;
+      const idAndroidArray = ID.split("_");
+      if (underscoreCount === 3) {
         if (idAndroidArray[3] === 1) {
           return true;
         }

--- a/functions/src/scripts/converter.ts
+++ b/functions/src/scripts/converter.ts
@@ -36,9 +36,6 @@ export async function convert(bulletinData: any, versionInput: any) {
                 continue;
             }
             if (!regex.test(vul.CVE)) {
-                const hyphenCount = vul.CVE.match(/-/g).length;
-                const vulCVEArray = vul.CVE.split("-");
-                if (hyphenCount !== 3) { //allow for CVE-___-___-1
                     const editedID = checkCVEValidity(vul.CVE, regex); //check if CVE is valid but malformed
                     if (editedID.length === 1) { //only one ID 
                         vul.CVE = editedID[0];
@@ -50,14 +47,6 @@ export async function convert(bulletinData: any, versionInput: any) {
                         }
                     }
                     continue;
-                } else if (vulCVEArray[3].length !== 1) { //check if fits -1 and if not check if valid
-                    const editedID = checkCVEValidity(vul.CVE, regex);
-                    if (editedID.length !== 0) {
-                        vul.CVE = editedID[0];
-                        subCVEData[vul.CVE] = buildSubCVEData(vul, versionNumber, data.published);
-                    }
-                    continue;
-                }
             }
 
             subCVEData[vul.CVE] = buildSubCVEData(vul, versionNumber, data.published);


### PR DESCRIPTION
Delete checks for -1 at end of CVE ID (only appears in patch analysis files). Clean up logic for Android Version validity. 